### PR TITLE
Fixes `cookbook/nodejs` issue.

### DIFF
--- a/cookbooks/nodejs/.kitchen.yml
+++ b/cookbooks/nodejs/.kitchen.yml
@@ -1,0 +1,74 @@
+---
+driver_plugin: vagrant
+driver_config:
+  require_chef_omnibus: true
+  customize:
+    memory: 512
+    cpus: 4
+
+platforms:
+- name: ubuntu-14.04
+  run_list:
+  - recipe[apt]
+- name: ubuntu-12.04
+  run_list:
+  - recipe[apt]
+- name: ubuntu-10.04
+  run_list:
+  - recipe[apt]
+- name: centos-6.5
+- name: centos-5.10
+
+suites:
+- name: default
+  run_list:
+  - recipe[nodejs]
+- name: package
+  run_list:
+  - recipe[nodejs]
+  attributes:
+    nodejs:
+      install_method: package
+- name: binary
+  run_list:
+  - recipe[nodejs]
+  attributes:
+    nodejs:
+      install_method: binary
+- name: source
+  run_list:
+  - recipe[nodejs]
+  attributes:
+    nodejs:
+      install_method: source
+- name: npm
+  run_list:
+  - recipe[nodejs::npm]
+  - recipe[nodejs_test::npm]
+- name: npm_embedded
+  run_list:
+  - recipe[nodejs::npm]
+  - recipe[nodejs_test::npm]
+  attributes:
+    nodejs:
+      npm:
+        install_method: embedded
+- name: npm_source
+  run_list:
+  - recipe[nodejs::npm]
+  - recipe[nodejs_test::npm]
+  attributes:
+    nodejs:
+      npm:
+        install_method: source
+- name: npm_packages
+  run_list: recipe[nodejs]
+  attributes:
+    nodejs:
+      npm_packages:
+        - name: express
+        - name: socket.io
+          version: 1.0.4
+        - name: express
+          action: uninstall
+

--- a/cookbooks/nodejs/.rubocop.yml
+++ b/cookbooks/nodejs/.rubocop.yml
@@ -1,0 +1,28 @@
+AllCops:
+  Include:
+    - '**/Berksfile'
+    - '**/Gemfile'
+    - '**/Rakefile'
+    - '**/Thorfile'
+    - '**/Guardfile'
+  Exclude:
+    - 'vendor/**/*'
+
+ClassLength:
+  Enabled: false
+Documentation:
+  Enabled: false
+Encoding:
+  Enabled: false
+HashSyntax:
+  Enabled: false
+LineLength:
+  Enabled: false
+MethodLength:
+  Enabled: false
+SignalException:
+  Enabled: false
+TrailingComma:
+  Enabled: false
+WordArray:
+  Enabled: false

--- a/cookbooks/nodejs/.travis.yml
+++ b/cookbooks/nodejs/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+bundler_args: --without integration
+cache: bundler
+sudo: false
+rvm:
+  - 1.9.3
+  - 2.0.0
+script: bundle exec rake travis

--- a/cookbooks/nodejs/Berksfile
+++ b/cookbooks/nodejs/Berksfile
@@ -1,0 +1,8 @@
+source 'https://supermarket.chef.io/'
+
+metadata
+
+group :integration do
+  cookbook 'apt'
+  cookbook 'nodejs_test', :path => './test/cookbooks/nodejs_test'
+end

--- a/cookbooks/nodejs/CHANGELOG.md
+++ b/cookbooks/nodejs/CHANGELOG.md
@@ -1,0 +1,87 @@
+## v2.4.0
+  * Move `npm_packages` to his own recipe
+  * Fix different race conditions when using direct recipe call
+  * Fix npm recipe
+
+## v2.3.2
+  * Fix package recipe
+
+## v2.3.0
+  * Support io.js. Use node['nodejs']['engine'].
+  * Add MacOS support via homebrew
+
+## v2.2.0
+  * Add node['nodejs']['keyserver']
+  * Update arm checksum
+  * Fix `npm_packages` JSON
+
+## v2.1.0
+  * Use official nodesource repository
+  * Add node['nodejs']['npm_packages'] to install npm package with `default` recipe
+
+## v2.0.0 
+  * Travis integration
+  * Gems updated
+  * Rewrite cookbook dependencies
+  * Added complete test-kitchen integration : Rake, rubocop, foodcritic, vagrant, bats testing ...
+  * Added NodeJS ```install_method``` option (sources, bins or packages)
+  * Added NPM ```install_method``` option (sources or packages)
+  * NPM version can now be chosen independently from nodejs' embedded version
+  * Added a ```nodejs_npm``` LWRP to manage, install and resolve NPM packages
+
+## v1.3.0
+  * update default versions to the latest: node - v0.10.15 and npm - v1.3.5
+  * default to package installation of nodejs on smartos ([@wanelo-pair][])
+  * Add Raspberry pi support ([@robertkowalski][])
+
+## v1.2.0
+  * implement installation from package on RedHat - ([@vaskas][])
+
+## v1.1.3:
+  * update default version of node to 0.10.13 - and npm - v1.3.4 ([@jodosha][])
+
+## v1.1.2:
+  * update default version of node to 0.10.2 - ([@bakins][])
+  * fully migrated to test-kitchen 1.alpha and vagrant 1.1.x/berkshelf 1.3.1
+
+## v1.1.1:
+  * update default versions to the latest: node - v0.10.0 and npm - v1.2.14
+  * `make_thread` is now a real attribute - ([@ChrisLundquist][])
+
+
+## v1.1.0:
+  * rewrite the package install; remove rpm support since there are no longer any packages available anywhere
+  * add support to install `legacy_packages` from ubuntu repo as well as the latest 0.10.x branch (this is default).
+
+## v1.0.4:
+  * add support for binary installation method ([@JulesAU][])
+
+## v1.0.3:
+  - unreleased
+
+## v1.0.2:
+  * add smartos support for package install ([@sax][])
+  * support to compile with all processors available (default 2 if unknown) - ([@ChrisLundquist][])
+  * moved to `platform_family` syntax
+  * ensure npm recipe honours the 'source' or 'package' setting - ([@markbirbeck][])
+  * updated the default versions to the latest stable node/npm
+
+## v1.0.1:
+
+ * fixed bug that prevented overwritting the node/npm versions (moved the `src_url`s as local variables instead of attributes) - ([@johannesbecker][])
+ * updated the default versions to the latest node/npm
+
+## v1.0.0:
+
+* added packages installation support ([@smith][])
+
+[@JulesAU]: https://github.com/JulesAU
+[@sax]: https://github.com/sax
+[@ChrisLundquist]: https://github.com/ChrisLundquist
+[@markbirbeck]: https://github.com/markbirbeck
+[@johannesbecker]: https://github.com/johannesbecker
+[@smith]: https://github.com/smith
+[@bakins]: https://github.com/bakins
+[@vaskas]: https://github.com/vaskas
+[@robertkowalski]: https://github.com/robertkowalski
+[@wanelo-pair]: https://github.com/wanelo-pair

--- a/cookbooks/nodejs/Gemfile
+++ b/cookbooks/nodejs/Gemfile
@@ -1,0 +1,15 @@
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'berkshelf', '~> 3.1.4'
+gem 'stove'
+
+group :test do
+  gem 'foodcritic', '~> 4.0.0'
+  gem 'rubocop', '~> 0.24.1'
+end
+
+group :integration do
+  gem 'test-kitchen', '~> 1.2.1'
+  gem 'kitchen-vagrant', '~> 0.15.0'
+end

--- a/cookbooks/nodejs/README.md
+++ b/cookbooks/nodejs/README.md
@@ -1,0 +1,145 @@
+# [nodejs-cookbook](https://github.com/redguide/nodejs)
+[![CK Version](http://img.shields.io/cookbook/v/nodejs.svg)](https://supermarket.getchef.com/cookbooks/nodejs) [![Build Status](https://img.shields.io/travis/redguide/nodejs.svg)](https://travis-ci.org/redguide/nodejs)
+[![Gitter chat](https://badges.gitter.im/redguide/nodejs.png)](https://gitter.im/redguide/nodejs)
+
+## DESCRIPTION
+
+Installs node.js/io.js and manage npm
+
+## USAGE
+
+Include the nodejs recipe to install node on your system based on the default installation method:
+```chef
+include_recipe "nodejs"
+```
+
+### Engine
+
+You can select different engine by setting `node['nodejs']['engine']`
+```
+node['nodejs']['engine'] => 'node' # default
+node['nodejs']['engine'] => 'iojs'
+```
+
+You can also use recipes `nodejs::nodejs` or `nodejs::iojs`.
+
+### Install methods
+
+#### Package
+
+Install node from packages:
+
+```chef
+node['nodejs']['install_method'] = 'package' # Not necessary because it's the default
+include_recipe "nodejs"
+# Or
+include_recipe "nodejs::nodejs_from_package"
+```
+Note that only apt (Ubuntu, Debian) appears to have up to date packages available. 
+Centos, RHEL, etc are non-functional (try `nodejs_from_binary` for those).
+
+#### Binary
+
+Install node from official prebuilt binaries:
+```chef
+node['nodejs']['install_method'] = 'binary'
+include_recipe "nodejs"
+# Or
+include_recipe "nodejs::nodejs_from_binary"
+```
+
+#### Source
+
+Install node from sources:
+```chef
+node['nodejs']['install_method'] = 'source'
+include_recipe "nodejs"
+# Or
+include_recipe "nodejs::nodejs_from_source"
+```
+
+## NPM
+
+Npm is included in nodejs installs by default.
+By default, we are using it and call it `embedded`.
+Adding recipe `nodejs::npm` assure you to have npm installed and let you choose install method with `node['nodejs']['npm']['install_method']`
+```chef
+include_recipe "nodejs::npm"
+```
+_Warning:_ This recipe will include the `nodejs` recipe, which by default includes `nodejs::nodejs_from_package` if you did not set `node['nodejs']['install_method']`.
+
+## LWRP
+
+### nodejs_npm
+
+`nodejs_npm` let you install npm packages from various sources:
+* npm registry:
+ * name: `attribute :package`
+ * version: `attribute :version` (optionnal)
+* url: `attribute :url`
+ * for git use `git://{your_repo}`
+* from a json (packages.json by default): `attribute :json`
+ * use `true` for default
+ * use a `String` to specify json file
+ 
+Packages can be installed globally (by default) or in a directory (by using `attribute :path`)
+
+You can append more specific options to npm command with `attribute :options` array :  
+ * use an array of options (w/ dash), they will be added to npm call.
+ * ex: `['--production','--force']` or `['--force-latest']`
+ 
+This LWRP try to use npm bare as much as possible (no custom wrapper).
+
+### Packages
+
+```ruby
+nodejs_npm "express"
+
+nodejs_npm "async" do
+  version "0.6.2"
+end
+
+nodejs_npm "request" do
+  url "github mikeal/request"
+end
+
+nodejs_npm "grunt" do
+  path "/home/random/grunt"
+  json true
+  user "random"
+end
+```
+[Working Examples](test/cookbooks/nodejs_test/recipes/npm.rb)
+
+Or add packages via attributes (which accept the same attributes as the LWRP above):
+
+```json
+"nodejs": {
+  "npm_packages": [
+    {
+      "name": "express"
+    },
+    {
+      "name": "async",
+      "version": "0.6.2"
+    },
+    {
+      "name": "request",
+      "url": "github mikeal/request"
+    }
+    {
+      "name": "grunt",
+      "path": "/home/random/grunt",
+      "json": true,
+      "user": "random"
+    }
+  ]
+}
+```
+
+## AUTHORS
+
+* Marius Ducea (marius@promethost.com)
+* Nathan L Smith (nlloyds@gmail.com)
+* Guilhem Lettron (guilhem@lettron.fr)
+* Barthelemy Vessemont (bvessemont@gmail.com)

--- a/cookbooks/nodejs/Rakefile
+++ b/cookbooks/nodejs/Rakefile
@@ -1,0 +1,51 @@
+#!/usr/bin/env rake
+
+# Style tests. Rubocop and Foodcritic
+namespace :style do
+  begin
+    require 'rubocop/rake_task'
+    desc 'Run Ruby style checks'
+    RuboCop::RakeTask.new(:ruby)
+  rescue LoadError
+    puts '>>>>> Rubocop gem not loaded, omitting tasks' unless ENV['CI']
+  end
+
+  begin
+    require 'foodcritic'
+
+    desc 'Run Chef style checks'
+    FoodCritic::Rake::LintTask.new(:chef) do |t|
+      t.options = {
+        fail_tags: ['any']
+      }
+    end
+  rescue LoadError
+    puts '>>>>> foodcritic gem not loaded, omitting tasks' unless ENV['CI']
+  end
+end
+
+desc 'Run all style checks'
+task style: ['style:chef', 'style:ruby']
+
+# Integration tests. Kitchen.ci
+namespace :integration do
+  begin
+    require 'kitchen/rake_tasks'
+
+    desc 'Run kitchen integration tests'
+    Kitchen::RakeTasks.new
+  rescue LoadError
+    puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
+  end
+end
+
+namespace :maintain do
+  require 'stove/rake_task'
+  Stove::RakeTask.new
+end
+
+desc 'Run all tests on Travis'
+task travis: ['style']
+
+# Default
+task default: ['style', 'integration:kitchen:all']

--- a/cookbooks/nodejs/attributes/default.rb
+++ b/cookbooks/nodejs/attributes/default.rb
@@ -1,0 +1,45 @@
+#
+# Cookbook Name:: nodejs
+# Attributes:: nodejs
+#
+# Copyright 2010-2012, Promet Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+case node['platform_family']
+when 'smartos', 'rhel', 'debian', 'fedora', 'mac_os_x'
+  default['nodejs']['install_method'] = 'package'
+else
+  default['nodejs']['install_method'] = 'source'
+end
+
+default['nodejs']['engine'] = 'node' # or iojs
+
+default['nodejs']['version'] = '0.10.26'
+
+if node['nodejs']['engine'] == 'iojs'
+  default['nodejs']['prefix_url'] = 'http://iojs.org/dist/'
+else
+  default['nodejs']['prefix_url'] = 'http://nodejs.org/dist/'
+end
+
+default['nodejs']['source']['url']      = nil # Auto generated
+default['nodejs']['source']['checksum'] = 'ef5e4ea6f2689ed7f781355012b942a2347e0299da0804a58de8e6281c4b1daa'
+
+default['nodejs']['binary']['url'] = nil # Auto generated
+default['nodejs']['binary']['checksum']['linux_x64'] = '305bf2983c65edea6dd2c9f3669b956251af03523d31cf0a0471504fd5920aac'
+default['nodejs']['binary']['checksum']['linux_x86'] = '8fa2d952556c8b5aa37c077e2735c972c522510facaa4df76d4244be88f4dc0f'
+default['nodejs']['binary']['checksum']['linux_arm-pi'] = '52a0f6ed9c0be1ea5f79de6527c481c1b803edbea6413a4fdc65a45ad401565d'
+
+default['nodejs']['make_threads'] = node['cpu'] ? node['cpu']['total'].to_i : 2

--- a/cookbooks/nodejs/attributes/npm.rb
+++ b/cookbooks/nodejs/attributes/npm.rb
@@ -1,0 +1,3 @@
+default['nodejs']['npm']['install_method'] = 'embedded'
+
+default['nodejs']['npm']['version'] = 'latest'

--- a/cookbooks/nodejs/attributes/packages.rb
+++ b/cookbooks/nodejs/attributes/packages.rb
@@ -1,0 +1,14 @@
+include_attribute 'nodejs::default'
+include_attribute 'nodejs::repo'
+
+case node['nodejs']['engine']
+when 'node'
+  default['nodejs']['packages'] = value_for_platform_family(
+    'debian' => node['nodejs']['install_repo'] ? ['nodejs'] : ['nodejs', 'npm', 'nodejs-dev'],
+    ['rhel', 'fedora'] => ['nodejs', 'nodejs-devel', 'npm'],
+    'mac_os_x' => ['node'],
+    'default' => ['nodejs']
+  )
+when 'iojs'
+  default['nodejs']['packages'] = nil
+end

--- a/cookbooks/nodejs/attributes/repo.rb
+++ b/cookbooks/nodejs/attributes/repo.rb
@@ -1,0 +1,13 @@
+case node['nodejs']['engine']
+when 'node'
+  case node['platform_family']
+  when 'debian'
+    default['nodejs']['install_repo'] = true
+
+    default['nodejs']['repo']      = 'https://deb.nodesource.com/node'
+    default['nodejs']['keyserver'] = 'keyserver.ubuntu.com'
+    default['nodejs']['key']       = '1655a0ab68576280'
+  when 'rhel'
+    default['nodejs']['install_repo'] = true
+  end
+end

--- a/cookbooks/nodejs/chefignore
+++ b/cookbooks/nodejs/chefignore
@@ -1,0 +1,96 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml
+

--- a/cookbooks/nodejs/libraries/matchers.rb
+++ b/cookbooks/nodejs/libraries/matchers.rb
@@ -1,0 +1,9 @@
+if defined?(ChefSpec)
+  def install_nodejs_npm(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:nodejs_npm, :install, resource_name)
+  end
+
+  def uninstall_nodejs_npm(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:nodejs_npm, :uninstall, resource_name)
+  end
+end

--- a/cookbooks/nodejs/libraries/nodejs_helper.rb
+++ b/cookbooks/nodejs/libraries/nodejs_helper.rb
@@ -1,0 +1,41 @@
+module NodeJs
+  module Helper
+    def npm_dist
+      if node['nodejs']['npm']['url']
+        return { 'url' => node['nodejs']['npm']['url'] }
+      else
+
+        require 'open-uri'
+        require 'json'
+        result = JSON.parse(URI.parse("https://registry.npmjs.org/npm/#{node['nodejs']['npm']['version']}").read, :max_nesting => false)
+        ret = { 'url' => result['dist']['tarball'], 'version' => result['_npmVersion'], 'shasum' => result['dist']['shasum'] }
+        Chef::Log.debug("Npm dist #{ret}")
+        return ret
+      end
+    end
+
+    def npm_list(path = nil)
+      require 'json'
+      if path
+        cmd = Mixlib::ShellOut.new('npm list -json', :cwd => path)
+      else
+        cmd = Mixlib::ShellOut.new('npm list -global -json')
+      end
+      JSON.parse(cmd.run_command.stdout, :max_nesting => false)
+    end
+
+    def url_valid?(list, package)
+      list.fetch(package, {}).fetch('resolved', '').include?('url')
+    end
+
+    def version_valid?(list, package, version)
+      (version ? list[package]['version'] == version : true)
+    end
+
+    def npm_package_installed?(package, version = nil, path = nil)
+      list = npm_list(path)['dependencies']
+      # Return true if package installed and installed to good version
+      (!list.nil?) && list.key?(package) && version_valid?(package, list, version) && url_valid?(list, package)
+    end
+  end
+end

--- a/cookbooks/nodejs/metadata.rb
+++ b/cookbooks/nodejs/metadata.rb
@@ -1,0 +1,23 @@
+name 'nodejs'
+maintainer 'redguide'
+maintainer_email 'guilhem@lettron.fr'
+license 'Apache 2.0'
+description 'Installs/Configures node.js & io.js'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+#source_url 'https://github.com/redguide/nodejs'
+#issues_url 'https://github.com/redguide/nodejs/issues'
+version '2.4.1'
+
+conflicts 'node'
+
+depends 'yum-epel'
+depends 'build-essential'
+depends 'ark'
+depends 'apt'
+depends 'homebrew'
+
+%w(debian ubuntu centos redhat smartos mac_os_x).each do |os|
+  supports os
+end
+
+suggests 'application_nodejs'

--- a/cookbooks/nodejs/providers/npm.rb
+++ b/cookbooks/nodejs/providers/npm.rb
@@ -1,0 +1,55 @@
+include NodeJs::Helper
+
+use_inline_resources if defined?(use_inline_resources)
+
+action :install do
+  execute "install NPM package #{new_resource.name}" do
+    cwd new_resource.path
+    command "npm install #{npm_options}"
+    user new_resource.user
+    group new_resource.group
+    environment 'HOME' => ::Dir.home(new_resource.user), 'USER' => new_resource.user if new_resource.user
+    not_if { package_installed? }
+  end
+end
+
+action :uninstall do
+  execute "uninstall NPM package #{new_resource.package}" do
+    cwd new_resource.path
+    command "npm uninstall #{npm_options}"
+    user new_resource.user
+    group new_resource.group
+    environment 'HOME' => ::Dir.home(new_resource.user), 'USER' => new_resource.user if new_resource.user
+    only_if { package_installed? }
+  end
+end
+
+def package_installed?
+  new_resource.package && npm_package_installed?(new_resource.package, new_resource.version, new_resource.path)
+end
+
+def npm_options
+  options = ''
+  options << ' -global' unless new_resource.path
+  new_resource.options.each do |option|
+    options << " #{option}"
+  end
+  options << " #{npm_package}"
+end
+
+def npm_package
+  if new_resource.json
+    return new_resource.json.is_a?(String) ? new_resource.json : nil
+  elsif new_resource.url
+    return new_resource.url
+  elsif new_resource.package
+    return new_resource.version ? "#{new_resource.package}@#{new_resource.version}" : new_resource.package
+  else
+    Chef::Log.error("No good options found to install #{new_resource.name}")
+  end
+end
+
+def initialize(*args)
+  super
+  @run_context.include_recipe 'nodejs::npm'
+end

--- a/cookbooks/nodejs/recipes/default.rb
+++ b/cookbooks/nodejs/recipes/default.rb
@@ -1,0 +1,23 @@
+#
+# Author:: Marius Ducea (marius@promethost.com)
+# Cookbook Name:: nodejs
+# Recipe:: default
+#
+# Copyright 2010-2012, Promet Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'nodejs::install'
+include_recipe 'nodejs::npm'
+include_recipe 'nodejs::npm_packages'

--- a/cookbooks/nodejs/recipes/install.rb
+++ b/cookbooks/nodejs/recipes/install.rb
@@ -1,0 +1,21 @@
+#
+# Author:: Marius Ducea (marius@promethost.com)
+# Cookbook Name:: nodejs
+# Recipe:: install
+#
+# Copyright 2010-2012, Promet Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe "nodejs::nodejs_from_#{node['nodejs']['install_method']}"

--- a/cookbooks/nodejs/recipes/iojs.rb
+++ b/cookbooks/nodejs/recipes/iojs.rb
@@ -1,0 +1,23 @@
+#
+# Author:: Marius Ducea (marius@promethost.com)
+# Cookbook Name:: nodejs
+# Recipe:: iojs
+#
+# Copyright 2010-2012, Promet Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+node.default['nodejs']['engine'] = 'iojs'
+
+include_recipe 'nodejs::install'

--- a/cookbooks/nodejs/recipes/nodejs.rb
+++ b/cookbooks/nodejs/recipes/nodejs.rb
@@ -1,0 +1,23 @@
+#
+# Author:: Marius Ducea (marius@promethost.com)
+# Cookbook Name:: nodejs
+# Recipe:: nodejs
+#
+# Copyright 2010-2012, Promet Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+node.default['nodejs']['engine'] = 'node'
+
+include_recipe 'nodejs::install'

--- a/cookbooks/nodejs/recipes/nodejs_from_binary.rb
+++ b/cookbooks/nodejs/recipes/nodejs_from_binary.rb
@@ -1,0 +1,58 @@
+#
+# Author:: Julian Wilde (jules@jules.com.au)
+# Cookbook Name:: nodejs
+# Recipe:: install_from_binary
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Chef::Recipe.send(:include, NodeJs::Helper)
+
+node.force_override['nodejs']['install_method'] = 'binary' # ~FC019
+
+# Shamelessly borrowed from http://docs.opscode.com/dsl_recipe_method_platform.html
+# Surely there's a more canonical way to get arch?
+if node['kernel']['machine'] =~ /armv6l/
+  arch = 'arm-pi' # assume a raspberry pi
+else
+  arch = node['kernel']['machine'] =~ /x86_64/ ? 'x64' : 'x86'
+end
+
+# package_stub is for example: "node-v0.8.20-linux-x64.tar.gz"
+version = "v#{node['nodejs']['version']}/"
+
+if node['nodejs']['engine'] == 'iojs'
+  filename = "iojs-v#{node['nodejs']['version']}-linux-#{arch}.tar.gz"
+  archive_name = 'iojs-binary'
+  binaries = ['bin/iojs', 'bin/node', 'bin/npm']
+else
+  filename = "node-v#{node['nodejs']['version']}-linux-#{arch}.tar.gz"
+  archive_name = 'nodejs-binary'
+  binaries = ['bin/node', 'bin/npm']
+end
+
+if node['nodejs']['binary']['url']
+  nodejs_bin_url = node['nodejs']['binary']['url']
+  checksum = node['nodejs']['binary']['checksum']
+else
+  nodejs_bin_url = ::URI.join(node['nodejs']['prefix_url'], version, filename).to_s
+  checksum = node['nodejs']['binary']['checksum']["linux_#{arch}"]
+end
+
+ark archive_name do
+  url nodejs_bin_url
+  version node['nodejs']['version']
+  checksum checksum
+  has_binaries binaries
+  action :install
+end

--- a/cookbooks/nodejs/recipes/nodejs_from_package.rb
+++ b/cookbooks/nodejs/recipes/nodejs_from_package.rb
@@ -1,0 +1,35 @@
+#
+# Author:: Nathan L Smith (nlloyds@gmail.com)
+# Author:: Marius Ducea (marius@promethost.com)
+# Cookbook Name:: nodejs
+# Recipe:: package
+#
+# Copyright 2012, Cramer Development, Inc.
+# Copyright 2013, Opscale
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+node.force_override['nodejs']['install_method'] = 'package' # ~FC019
+
+include_recipe 'nodejs::repo' if node['nodejs']['install_repo']
+
+unless node['nodejs']['packages']
+  Chef::Log.error 'No package for nodejs'
+  Chef::Log.warn 'Please use the source or binary method to install node'
+  return
+end
+
+node['nodejs']['packages'].each do |node_pkg|
+  package node_pkg
+end

--- a/cookbooks/nodejs/recipes/nodejs_from_source.rb
+++ b/cookbooks/nodejs/recipes/nodejs_from_source.rb
@@ -1,0 +1,52 @@
+#
+# Author:: Marius Ducea (marius@promethost.com)
+# Cookbook Name:: nodejs
+# Recipe:: source
+#
+# Copyright 2010-2012, Promet Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Chef::Recipe.send(:include, NodeJs::Helper)
+
+node.force_override['nodejs']['install_method'] = 'source' # ~FC019
+
+include_recipe 'build-essential'
+
+case node['platform_family']
+when 'rhel', 'fedora'
+  package 'openssl-devel'
+when 'debian'
+  package 'libssl-dev'
+end
+
+version = "v#{node['nodejs']['version']}/"
+
+if node['nodejs']['engine'] == 'iojs'
+  filename = "iojs-v#{node['nodejs']['version']}.tar.gz"
+  archive_name = 'iojs-source'
+else
+  filename = "node-v#{node['nodejs']['version']}.tar.gz"
+  archive_name = 'nodejs-source'
+end
+
+nodejs_src_url = node['nodejs']['source']['url'] || ::URI.join(node['nodejs']['prefix_url'], version, filename).to_s
+
+ark archive_name do
+  url nodejs_src_url
+  version node['nodejs']['version']
+  checksum node['nodejs']['source']['checksum']
+  make_opts ["-j #{node['nodejs']['make_threads']}"]
+  action :install_with_make
+end

--- a/cookbooks/nodejs/recipes/npm.rb
+++ b/cookbooks/nodejs/recipes/npm.rb
@@ -1,0 +1,28 @@
+#
+# Author:: Marius Ducea (marius@promethost.com)
+# Cookbook Name:: nodejs
+# Recipe:: npm
+#
+# Copyright 2010-2012, Promet Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+case node['nodejs']['npm']['install_method']
+when 'embedded'
+  include_recipe 'nodejs::install'
+when 'source'
+  include_recipe 'nodejs::npm_from_source'
+else
+  Chef::Log.error('No install method found for npm')
+end

--- a/cookbooks/nodejs/recipes/npm_from_source.rb
+++ b/cookbooks/nodejs/recipes/npm_from_source.rb
@@ -1,0 +1,34 @@
+#
+# Author:: Marius Ducea (marius@promethost.com)
+# Cookbook Name:: nodejs
+# Recipe:: npm
+#
+# Copyright 2010-2012, Promet Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Chef::Recipe.send(:include, NodeJs::Helper)
+
+node.force_override['nodejs']['npm']['install_method'] = 'source' # ~FC019
+
+include_recipe 'nodejs::install'
+
+dist = npm_dist
+
+ark 'npm' do
+  url dist['url']
+  checksum dist['checksum']
+  version dist['version']
+  action :install_with_make
+end

--- a/cookbooks/nodejs/recipes/npm_packages.rb
+++ b/cookbooks/nodejs/recipes/npm_packages.rb
@@ -1,0 +1,10 @@
+node['nodejs']['npm_packages'].each do |pkg|
+  f = nodejs_npm pkg['name'] do
+    action :nothing
+  end
+  pkg.each do |key, value|
+    f.send(key, value) unless key == 'name' || key == 'action'
+  end
+  action = pkg.key?('action') ? pkg['action'] : :install
+  f.action(action)
+end if node['nodejs'].key?('npm_packages')

--- a/cookbooks/nodejs/recipes/repo.rb
+++ b/cookbooks/nodejs/recipes/repo.rb
@@ -1,0 +1,16 @@
+case node['platform_family']
+when 'debian'
+  include_recipe 'apt'
+
+  package 'apt-transport-https'
+
+  apt_repository 'node.js' do
+    uri node['nodejs']['repo']
+    distribution node['lsb']['codename']
+    components ['main']
+    keyserver node['nodejs']['keyserver']
+    key node['nodejs']['key']
+  end
+when 'rhel'
+  include_recipe 'yum-epel'
+end

--- a/cookbooks/nodejs/resources/npm.rb
+++ b/cookbooks/nodejs/resources/npm.rb
@@ -1,0 +1,33 @@
+#
+# Cookbook Name:: nodejs
+# Resource:: npm
+#
+# Author:: Sergey Balbeko <sergey@balbeko.com>
+#
+# Copyright 2012, Sergey Balbeko
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :install, :uninstall
+default_action :install
+
+attribute :package, :name_attribute => true
+attribute :version, :kind_of => String
+attribute :path, :kind_of => String
+attribute :url, :kind_of => String
+attribute :json, :kind_of => [String, TrueClass]
+attribute :options, :kind_of => Array, :default => []
+
+attribute :user, :kind_of => String
+attribute :group, :kind_of => String

--- a/cookbooks/nodejs/test/cookbooks/nodejs_test/metadata.rb
+++ b/cookbooks/nodejs/test/cookbooks/nodejs_test/metadata.rb
@@ -1,0 +1,4 @@
+name 'nodejs_test'
+version '0.1.0'
+
+depends 'git'

--- a/cookbooks/nodejs/test/cookbooks/nodejs_test/recipes/npm.rb
+++ b/cookbooks/nodejs/test/cookbooks/nodejs_test/recipes/npm.rb
@@ -1,0 +1,32 @@
+include_recipe 'git'
+
+user 'random' do
+  supports :manage_home => true
+  home '/home/random'
+end
+
+# global "express"
+nodejs_npm 'express'
+
+nodejs_npm 'async' do
+  version '0.6.2'
+end
+
+nodejs_npm 'request' do
+  url 'github mikeal/request'
+end
+
+git '/home/random/grunt' do
+  repository 'https://github.com/gruntjs/grunt'
+  user 'random'
+end
+
+nodejs_npm 'grunt' do
+  path '/home/random/grunt'
+  json true
+  user 'random'
+end
+
+nodejs_npm 'mocha' do
+  options ['--force', '--production']
+end

--- a/cookbooks/nodejs/test/integration/package/bats/package.bats
+++ b/cookbooks/nodejs/test/integration/package/bats/package.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+@test "node should be in the path" {
+  [ "$(command -v node)" ]
+}
+
+@test "npm should be in the path" {
+  [ "$(command -v npm)" ]
+}

--- a/cookbooks/nodejs/test/integration/source/bats/source.bats
+++ b/cookbooks/nodejs/test/integration/source/bats/source.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+@test "node should be in the path" {
+  [ "$(command -v node)" ]
+}
+
+@test "npm should be in the path" {
+  [ "$(command -v npm)" ]
+}


### PR DESCRIPTION
This PR fixes the issue because of what nodejs cookbook weren't getting cloned and thus resulting in failure while installing node js in the vagrant box.